### PR TITLE
feat: generic lookups

### DIFF
--- a/crates/toto_ast/src/lib.rs
+++ b/crates/toto_ast/src/lib.rs
@@ -1,5 +1,6 @@
 use petgraph::{Directed, Graph};
 
 pub type GraphHandle = petgraph::graph::NodeIndex<u32>;
+pub type EdgeHandle = petgraph::graph::EdgeIndex<u32>;
 
 pub type AST<E, R> = Graph<E, R, Directed, u32>;

--- a/crates/toto_lsp/src/main.rs
+++ b/crates/toto_lsp/src/main.rs
@@ -16,7 +16,7 @@ mod models;
 
 use models::*;
 use toto_parser::{get_errors, get_yaml_len, AsParseError, AsParseLoc};
-use toto_tosca::{AsToscaEntity, AsToscaRelation};
+use toto_tosca::{AsToscaEntity, AsToscaRelation, ImportTargetRelation};
 use toto_yaml::{AsFileEntity, AsFileRelation, AsYamlEntity};
 
 fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
@@ -271,7 +271,10 @@ impl Server {
             .flatten()
             .find_map(|e| match e.weight().as_tosca() {
                 Some(toto_tosca::Relation::Ref(referencer)) => {
-                    Some((e.source(), referencer.lookuper.clone()))
+                    Some((e.source(), referencer.lookuper.then.clone()))
+                }
+                Some(toto_tosca::Relation::ImportUrl(_)) => {
+                    Some((e.source(), toto_tosca::Relation::from(ImportTargetRelation)))
                 }
                 _ => None,
             });
@@ -286,7 +289,7 @@ impl Server {
             .ast
             .edges_directed(semantic_token.0, Outgoing)
             .find_map(|e| {
-                if e.weight().as_tosca() == Some(&semantic_token.1.then) {
+                if e.weight().as_tosca() == Some(&semantic_token.1) {
                     Some(e.target())
                 } else {
                     None

--- a/crates/toto_lsp/src/main.rs
+++ b/crates/toto_lsp/src/main.rs
@@ -270,13 +270,9 @@ impl Server {
             })
             .flatten()
             .find_map(|e| match e.weight().as_tosca() {
-                Some(
-                    toto_tosca::Relation::ImportUrl(_)
-                    | toto_tosca::Relation::RefHasType(_)
-                    | toto_tosca::Relation::RefDerivedFrom(_)
-                    | toto_tosca::Relation::RefMemberNodeType(_)
-                    | toto_tosca::Relation::RefValidSourceNodeType(_),
-                ) => Some(e.source()),
+                Some(toto_tosca::Relation::Ref(referencer)) => {
+                    Some((e.source(), referencer.lookuper.clone()))
+                }
                 _ => None,
             });
 
@@ -286,34 +282,16 @@ impl Server {
         }
         let semantic_token = semantic_token.unwrap();
 
-        let goto_target = match self.ast[semantic_token].as_tosca() {
-            Some(toto_tosca::Entity::Import(_)) => self
-                .ast
-                .edges_directed(semantic_token, Outgoing)
-                .find_map(|e| match e.weight().as_tosca() {
-                    Some(toto_tosca::Relation::ImportTarget(_)) => Some(e.target()),
-                    _ => None,
-                }),
-            Some(
-                toto_tosca::Entity::Node(_)
-                | toto_tosca::Entity::Data(_)
-                | toto_tosca::Entity::Capability(_)
-                | toto_tosca::Entity::Relationship(_)
-                | toto_tosca::Entity::Artifact(_)
-                | toto_tosca::Entity::Policy(_)
-                | toto_tosca::Entity::Interface(_)
-                | toto_tosca::Entity::Group(_),
-            ) => self
-                .ast
-                .edges_directed(semantic_token, Outgoing)
-                .find_map(|e| match e.weight().as_tosca() {
-                    Some(
-                        toto_tosca::Relation::HasType(_) | toto_tosca::Relation::DerivedFrom(_),
-                    ) => Some(e.target()),
-                    _ => None,
-                }),
-            _ => None,
-        };
+        let goto_target = self
+            .ast
+            .edges_directed(semantic_token.0, Outgoing)
+            .find_map(|e| {
+                if e.weight().as_tosca() == Some(&semantic_token.1.then) {
+                    Some(e.target())
+                } else {
+                    None
+                }
+            });
 
         if goto_target.is_none() {
             eprintln!("can't go to definition (no target)");

--- a/crates/toto_tosca/src/grammar/collection.rs
+++ b/crates/toto_tosca/src/grammar/collection.rs
@@ -29,6 +29,11 @@ where
                         *v_handle,
                         crate::Relation::from(K::from(k_str.0.clone())).into(),
                     );
+                    ast.add_edge(
+                        *v_handle,
+                        root,
+                        crate::Relation::Root(crate::RootRelation).into(),
+                    );
                 });
             });
         }

--- a/crates/toto_tosca/src/grammar/field.rs
+++ b/crates/toto_tosca/src/grammar/field.rs
@@ -15,6 +15,11 @@ where
     fn parse(root: toto_ast::GraphHandle, n: toto_ast::GraphHandle, ast: &mut toto_ast::AST<E, R>) {
         if let Some(n_handle) = V::parse(n, ast) {
             ast.add_edge(root, n_handle, crate::Relation::from(C::default()).into());
+            ast.add_edge(
+                n_handle,
+                root,
+                crate::Relation::Root(crate::RootRelation).into(),
+            );
         }
     }
 }

--- a/crates/toto_tosca/src/grammar/field_ref.rs
+++ b/crates/toto_tosca/src/grammar/field_ref.rs
@@ -1,0 +1,57 @@
+use toto_parser::EntityParser;
+
+use crate::{
+    semantic::SimpleLookuper, DerivedFromRelation, FileEntity, HasTypeRelation, RefRelation,
+    RefRootRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, TypeRelation,
+};
+
+use super::v2_0::value;
+
+pub struct FieldRef(pub SimpleLookuper);
+
+impl FieldRef {
+    pub fn derived_from(entity: crate::Entity) -> Self {
+        Self(SimpleLookuper {
+            root: (
+                crate::Relation::from(RefRootRelation),
+                crate::Entity::from(FileEntity),
+            ),
+            what: entity,
+            what_rel: |s| crate::Relation::from(TypeRelation::from(s)),
+            then: crate::Relation::from(DerivedFromRelation),
+        })
+    }
+
+    pub fn has_type(entity: crate::Entity) -> Self {
+        Self(SimpleLookuper {
+            root: (
+                crate::Relation::from(RefRootRelation),
+                crate::Entity::from(FileEntity),
+            ),
+            what: entity,
+            what_rel: |s| crate::Relation::from(TypeRelation::from(s)),
+            then: crate::Relation::from(HasTypeRelation),
+        })
+    }
+
+    pub fn parse<E, R>(
+        self,
+        root: toto_ast::GraphHandle,
+        n: toto_ast::GraphHandle,
+        ast: &mut toto_ast::AST<E, R>,
+    ) where
+        E: ToscaCompatibleEntity,
+        R: ToscaCompatibleRelation,
+    {
+        if let Some(n_handle) = value::StringValue::parse(n, ast) {
+            ast.add_edge(
+                root,
+                n_handle,
+                crate::Relation::from(RefRelation {
+                    lookuper: Box::new(self.0),
+                })
+                .into(),
+            );
+        }
+    }
+}

--- a/crates/toto_tosca/src/grammar/field_ref.rs
+++ b/crates/toto_tosca/src/grammar/field_ref.rs
@@ -2,7 +2,7 @@ use toto_parser::EntityParser;
 
 use crate::{
     semantic::SimpleLookuper, DerivedFromRelation, FileEntity, HasTypeRelation, RefRelation,
-    RefRootRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, TypeRelation,
+    RootRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, TypeRelation,
 };
 
 use super::v2_0::value;
@@ -13,7 +13,7 @@ impl FieldRef {
     pub fn derived_from(entity: crate::Entity) -> Self {
         Self(SimpleLookuper {
             root: (
-                crate::Relation::from(RefRootRelation),
+                crate::Relation::from(RootRelation),
                 crate::Entity::from(FileEntity),
             ),
             what: entity,
@@ -25,7 +25,7 @@ impl FieldRef {
     pub fn has_type(entity: crate::Entity) -> Self {
         Self(SimpleLookuper {
             root: (
-                crate::Relation::from(RefRootRelation),
+                crate::Relation::from(RootRelation),
                 crate::Entity::from(FileEntity),
             ),
             what: entity,

--- a/crates/toto_tosca/src/grammar/field_ref.rs
+++ b/crates/toto_tosca/src/grammar/field_ref.rs
@@ -1,9 +1,8 @@
 use toto_parser::EntityParser;
 
 use crate::{
-    semantic::SimpleLookuper, DerivedFromRelation, FileEntity, HasTypeRelation, RefRelation,
-    RootRelation, SubstitutesTypeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
-    TypeRelation,
+    semantic::SimpleLookuper, DefinitionRelation, FileEntity, RefRelation, RootRelation,
+    ServiceTemplateEntity, ToscaCompatibleEntity, ToscaCompatibleRelation, TypeRelation,
 };
 
 use super::v2_0::value;
@@ -11,39 +10,35 @@ use super::v2_0::value;
 pub struct FieldRef(pub SimpleLookuper);
 
 impl FieldRef {
-    pub fn derived_from(entity: crate::Entity) -> Self {
+    pub fn type_ref<E, R>(entity: E, relation: R) -> Self
+    where
+        crate::Entity: From<E>,
+        crate::Relation: From<R>,
+    {
         Self(SimpleLookuper {
             root: (
-                crate::Relation::from(RootRelation),
-                crate::Entity::from(FileEntity),
+                crate::Relation::Root(RootRelation),
+                crate::Entity::File(FileEntity),
             ),
-            what: entity,
-            what_rel: |s| crate::Relation::from(TypeRelation::from(s)),
-            then: crate::Relation::from(DerivedFromRelation),
+            what: crate::Entity::from(entity),
+            what_rel: |s| crate::Relation::Type(TypeRelation::from(s)),
+            then: crate::Relation::from(relation),
         })
     }
 
-    pub fn has_type(entity: crate::Entity) -> Self {
+    pub fn def_ref<E, R>(entity: E, relation: R) -> Self
+    where
+        crate::Entity: From<E>,
+        crate::Relation: From<R>,
+    {
         Self(SimpleLookuper {
             root: (
-                crate::Relation::from(RootRelation),
-                crate::Entity::from(FileEntity),
+                crate::Relation::Root(RootRelation),
+                crate::Entity::ServiceTemplate(ServiceTemplateEntity),
             ),
-            what: entity,
-            what_rel: |s| crate::Relation::from(TypeRelation::from(s)),
-            then: crate::Relation::from(HasTypeRelation),
-        })
-    }
-
-    pub fn substitutes_type(entity: crate::Entity) -> Self {
-        Self(SimpleLookuper {
-            root: (
-                crate::Relation::from(RootRelation),
-                crate::Entity::from(FileEntity),
-            ),
-            what: entity,
-            what_rel: |s| crate::Relation::from(TypeRelation::from(s)),
-            then: crate::Relation::from(SubstitutesTypeRelation),
+            what: crate::Entity::from(entity),
+            what_rel: |s| crate::Relation::Definition(DefinitionRelation::from(s)),
+            then: crate::Relation::from(relation),
         })
     }
 

--- a/crates/toto_tosca/src/grammar/list.rs
+++ b/crates/toto_tosca/src/grammar/list.rs
@@ -24,6 +24,11 @@ where
                 items.for_each(|(i, v)| {
                     V::parse(v, ast).map(|v_handle| {
                         ast.add_edge(root, v_handle, crate::Relation::from(K::from(i)).into());
+                        ast.add_edge(
+                            v_handle,
+                            root,
+                            crate::Relation::Root(crate::RootRelation).into(),
+                        );
                         v_handle
                     });
                 });
@@ -69,6 +74,11 @@ where
                                         root,
                                         *v_handle,
                                         crate::Relation::from(K::from((k_str.0.clone(), i))).into(),
+                                    );
+                                    ast.add_edge(
+                                        *v_handle,
+                                        root,
+                                        crate::Relation::Root(crate::RootRelation).into(),
                                     );
                                 });
                             } else {

--- a/crates/toto_tosca/src/grammar/mod.rs
+++ b/crates/toto_tosca/src/grammar/mod.rs
@@ -2,7 +2,6 @@ use crate::{ToscaCompatibleEntity, ToscaCompatibleRelation};
 
 pub mod collection;
 pub mod field;
-pub mod hierarchy;
 pub mod list;
 pub mod parser;
 // pub mod v1_3;

--- a/crates/toto_tosca/src/grammar/mod.rs
+++ b/crates/toto_tosca/src/grammar/mod.rs
@@ -2,6 +2,7 @@ use crate::{ToscaCompatibleEntity, ToscaCompatibleRelation};
 
 pub mod collection;
 pub mod field;
+pub mod field_ref;
 pub mod list;
 pub mod parser;
 // pub mod v1_3;

--- a/crates/toto_tosca/src/grammar/parser.rs
+++ b/crates/toto_tosca/src/grammar/parser.rs
@@ -2,7 +2,7 @@ use toto_parser::add_with_loc;
 
 use crate::{ToscaCompatibleEntity, ToscaCompatibleRelation};
 
-use super::{hierarchy::Hierarchy, v2_0::Tosca2_0};
+use super::v2_0::Tosca2_0;
 
 pub struct ToscaGrammar;
 
@@ -70,6 +70,5 @@ where
                     None
                 }
             })
-            .map(|file_handle| Hierarchy::link(file_handle, ast))
     }
 }

--- a/crates/toto_tosca/src/grammar/v2_0/artifact.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/artifact.rs
@@ -3,13 +3,18 @@ use std::{collections::HashSet, marker::PhantomData};
 use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, EntrySchemaRelation,
-    ExternalSchemaRelation, FileExtRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
-    MimeTypeRelation, PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation,
-    RefHasTypeRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
+    grammar::{
+        collection::Collection, field::Field, field_ref::FieldRef, list::List,
+        ToscaDefinitionsVersion,
+    },
+    semantic::SimpleLookuper,
+    ArtifactEntity, AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation,
+    DefaultRelation, DefinitionRelation, DependencyArtifactRelation, DerivedFromRelation,
+    DescriptionRelation, EntrySchemaRelation, ExternalSchemaRelation, FileEntity, FileExtRelation,
+    HasTypeRelation, KeySchemaRelation, MappingRelation, MetadataRelation, MimeTypeRelation,
+    PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation,
+    RefRootRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
+    ToscaCompatibleRelation, TypeRelation, ValidationRelation, ValueRelation, VersionRelation,
 };
 
 use super::value;
@@ -34,7 +39,8 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::ArtifactEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => Field::<RefDerivedFromRelation, value::StringValue>::parse,
+        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(ArtifactEntity)).parse(r, n, ast),
+
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -52,7 +58,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::ArtifactEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(ArtifactEntity)).parse(r, n, ast),
         "file" => Field::<RefHasFileRelation, value::StringValue>::parse,
         "repository" => Field::<RepositoryRelation, value::StringValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/artifact.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/artifact.rs
@@ -1,20 +1,16 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{add_with_loc, mandatory, RelationParser, Schema};
 
 use crate::{
     grammar::{
         collection::Collection, field::Field, field_ref::FieldRef, list::List,
         ToscaDefinitionsVersion,
     },
-    semantic::SimpleLookuper,
-    ArtifactEntity, AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation,
-    DefaultRelation, DefinitionRelation, DependencyArtifactRelation, DerivedFromRelation,
-    DescriptionRelation, EntrySchemaRelation, ExternalSchemaRelation, FileEntity, FileExtRelation,
-    HasTypeRelation, KeySchemaRelation, MappingRelation, MetadataRelation, MimeTypeRelation,
-    PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation, RequiredRelation,
-    ToscaCompatibleEntity, ToscaCompatibleRelation, TypeRelation, ValidationRelation,
-    ValueRelation, VersionRelation,
+    ArtifactEntity, AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefinitionRelation, DependencyArtifactRelation,
+    DescriptionRelation, FileExtRelation, MetadataRelation, MimeTypeRelation,
+    PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/artifact.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/artifact.rs
@@ -12,9 +12,9 @@ use crate::{
     DefaultRelation, DefinitionRelation, DependencyArtifactRelation, DerivedFromRelation,
     DescriptionRelation, EntrySchemaRelation, ExternalSchemaRelation, FileEntity, FileExtRelation,
     HasTypeRelation, KeySchemaRelation, MappingRelation, MetadataRelation, MimeTypeRelation,
-    PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation,
-    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
-    TypeRelation, ValidationRelation, ValueRelation, VersionRelation,
+    PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation, RequiredRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation, TypeRelation, ValidationRelation,
+    ValueRelation, VersionRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/artifact.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/artifact.rs
@@ -100,10 +100,10 @@ where
                 <Self as toto_parser::Schema<E, R>>::parse_schema(implementation, items, ast)
             })
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                ast.add_edge(
+                FieldRef::def_ref(crate::ArtifactEntity, crate::PrimaryArtifactRelation).link(
                     implementation,
                     n,
-                    crate::Relation::from(crate::PrimaryArtifactRelation).into(),
+                    ast,
                 );
                 implementation
             }))
@@ -136,6 +136,11 @@ where
         let artifact = add_with_loc(crate::Entity::from(crate::ArtifactEntity), n, ast);
         toto_yaml::as_map(n, ast)
             .map(|items| ArtifactDefinition::<V>::parse_schema(artifact, items, ast))
+            .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
+                FieldRef::def_ref(crate::ArtifactEntity, crate::PrimaryArtifactRelation)
+                    .link(artifact, n, ast);
+                artifact
+            }))
             .or_else(|| {
                 add_with_loc(
                     toto_parser::ParseError::UnexpectedType("map or string"),

--- a/crates/toto_tosca/src/grammar/v2_0/artifact.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/artifact.rs
@@ -13,8 +13,8 @@ use crate::{
     DescriptionRelation, EntrySchemaRelation, ExternalSchemaRelation, FileEntity, FileExtRelation,
     HasTypeRelation, KeySchemaRelation, MappingRelation, MetadataRelation, MimeTypeRelation,
     PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation,
-    RefRootRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, TypeRelation, ValidationRelation, ValueRelation, VersionRelation,
+    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    TypeRelation, ValidationRelation, ValueRelation, VersionRelation,
 };
 
 use super::value;
@@ -40,7 +40,6 @@ where
     const SELF: fn() -> E = || crate::Entity::from(crate::ArtifactEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
         "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(ArtifactEntity)).parse(r, n, ast),
-
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/artifact.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/artifact.rs
@@ -7,10 +7,11 @@ use crate::{
         collection::Collection, field::Field, field_ref::FieldRef, list::List,
         ToscaDefinitionsVersion,
     },
-    ArtifactEntity, AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefinitionRelation, DependencyArtifactRelation,
-    DescriptionRelation, FileExtRelation, MetadataRelation, MimeTypeRelation,
-    PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation,
-    ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
+    ArtifactEntity, AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation,
+    DefinitionRelation, DependencyArtifactRelation, DerivedFromRelation, DescriptionRelation,
+    FileExtRelation, HasFileRelation, HasTypeRelation, MetadataRelation, MimeTypeRelation,
+    PrimaryArtifactRelation, RepositoryRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    VersionRelation,
 };
 
 use super::value;
@@ -35,7 +36,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::ArtifactEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(ArtifactEntity)).parse(r, n, ast),
+        "derived_from" => |r, n, ast| FieldRef::type_ref(ArtifactEntity, DerivedFromRelation).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -53,8 +54,8 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::ArtifactEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(ArtifactEntity)).parse(r, n, ast),
-        "file" => Field::<RefHasFileRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::type_ref(ArtifactEntity, HasTypeRelation).parse(r, n, ast),
+        "file" => Field::<HasFileRelation, value::StringValue>::parse,
         "repository" => Field::<RepositoryRelation, value::StringValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/capability.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/capability.rs
@@ -3,7 +3,10 @@ use std::{collections::HashSet, marker::PhantomData};
 use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
+    grammar::{
+        collection::Collection, field::Field, field_ref::FieldRef, list::List,
+        ToscaDefinitionsVersion,
+    },
     AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
@@ -33,7 +36,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::CapabilityEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => Field::<RefDerivedFromRelation, value::StringValue>::parse,
+        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::CapabilityEntity)).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -52,7 +55,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::CapabilityEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::CapabilityEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<DefinitionRelation, V::PropertyDefinition>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/capability.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/capability.rs
@@ -1,19 +1,14 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{add_with_loc, mandatory, RelationParser, Schema};
 
 use crate::{
     grammar::{
         collection::Collection, field::Field, field_ref::FieldRef, list::List,
         ToscaDefinitionsVersion,
     },
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
-    EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
-    MappingRelation, MetadataRelation, MimeTypeRelation, PrimaryArtifactRelation,
-    RefHasFileRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
-    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
-    ValidationRelation, ValueRelation, VersionRelation,
+    AssignmentRelation,
+    DefinitionRelation, DescriptionRelation, DirectiveRelation, MetadataRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/capability.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/capability.rs
@@ -11,10 +11,9 @@ use crate::{
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
     MappingRelation, MetadataRelation, MimeTypeRelation, PrimaryArtifactRelation,
-    RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation,
-    RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation, RepositoryRelation,
-    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
-    ValueRelation, VersionRelation,
+    RefHasFileRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
+    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    ValidationRelation, ValueRelation, VersionRelation,
 };
 
 use super::value;
@@ -96,11 +95,8 @@ where
         toto_yaml::as_map(n, ast)
             .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(capability, items, ast))
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                ast.add_edge(
-                    capability,
-                    n,
-                    crate::Relation::from(crate::RefHasTypeRelation).into(),
-                );
+                FieldRef::has_type(crate::Entity::from(crate::CapabilityEntity))
+                    .parse(capability, n, ast);
                 capability
             }))
             .or_else(|| {

--- a/crates/toto_tosca/src/grammar/v2_0/capability.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/capability.rs
@@ -1,14 +1,15 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, RelationParser, Schema};
+use toto_parser::{add_with_loc, mandatory, RelationParser};
 
 use crate::{
     grammar::{
         collection::Collection, field::Field, field_ref::FieldRef, list::List,
         ToscaDefinitionsVersion,
     },
-    AssignmentRelation,
-    DefinitionRelation, DescriptionRelation, DirectiveRelation, MetadataRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
+    AssignmentRelation, DefinitionRelation, DescriptionRelation, DirectiveRelation,
+    MetadataRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    ValidRelationshipTypeRelation, ValidSourceNodeTypeRelation, VersionRelation,
 };
 
 use super::value;
@@ -30,14 +31,14 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::CapabilityEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::CapabilityEntity)).parse(r, n, ast),
+        "derived_from" => |r, n, ast| FieldRef::type_ref(crate::CapabilityEntity, crate::DerivedFromRelation).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "properties" => Collection::<DefinitionRelation, V::PropertyDefinition>::parse,
         "attributes" => Collection::<DefinitionRelation, V::AttributeDefinition>::parse,
-        "valid_source_node_types" => List::<RefValidSourceNodeTypeRelation, value::StringValue>::parse,
-        "valid_relationship_types" => List::<RefValidRelationshipTypeRelation, value::StringValue>::parse,
+        "valid_source_node_types" => List::<ValidSourceNodeTypeRelation, value::StringValue>::parse,
+        "valid_relationship_types" => List::<ValidRelationshipTypeRelation, value::StringValue>::parse,
     };
 }
 
@@ -49,13 +50,13 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::CapabilityEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::CapabilityEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::CapabilityEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<DefinitionRelation, V::PropertyDefinition>::parse,
         "attributes" => Collection::<DefinitionRelation, V::AttributeDefinition>::parse,
-        "valid_source_node_types" => List::<RefValidSourceNodeTypeRelation, value::StringValue>::parse,
-        "valid_relationship_types" => List::<RefValidRelationshipTypeRelation, value::StringValue>::parse,
+        "valid_source_node_types" => List::<ValidSourceNodeTypeRelation, value::StringValue>::parse,
+        "valid_relationship_types" => List::<ValidRelationshipTypeRelation, value::StringValue>::parse,
     };
 
     const VALIDATION: &'static [toto_parser::ValidationFieldFn] =
@@ -90,8 +91,8 @@ where
         toto_yaml::as_map(n, ast)
             .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(capability, items, ast))
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                FieldRef::has_type(crate::Entity::from(crate::CapabilityEntity))
-                    .parse(capability, n, ast);
+                FieldRef::type_ref(crate::CapabilityEntity, crate::HasTypeRelation)
+                    .link(capability, n, ast);
                 capability
             }))
             .or_else(|| {

--- a/crates/toto_tosca/src/grammar/v2_0/data.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/data.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, marker::PhantomData};
 use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, ToscaDefinitionsVersion},
+    grammar::{collection::Collection, field::Field, field_ref::FieldRef, ToscaDefinitionsVersion},
     DefaultRelation, DefinitionRelation, DescriptionRelation, EntrySchemaRelation,
     ExternalSchemaRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
     RefDerivedFromRelation, RefHasTypeRelation, RequiredRelation, ToscaCompatibleEntity,
@@ -35,7 +35,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => Field::<RefDerivedFromRelation, value::StringValue>::parse,
+        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::StringValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -54,7 +54,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "validation" => Field::<ValidationRelation, value::AnyValue>::parse,
         "key_schema" => Field::<KeySchemaRelation, V::SchemaDefinition>::parse,
@@ -109,7 +109,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "default" => Field::<DefaultRelation, value::BoolValue>::parse,
         "status" => Field::<DefaultRelation, StatusValue>::parse,
@@ -131,7 +131,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "required" => Field::<RequiredRelation, value::BoolValue>::parse,
         "default" => Field::<DefaultRelation, value::AnyValue>::parse,
@@ -156,7 +156,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "required" => Field::<RequiredRelation, value::BoolValue>::parse,
         "default" => Field::<DefaultRelation, value::AnyValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/data.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/data.rs
@@ -35,7 +35,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
+        "derived_from" => |r, n, ast| FieldRef::type_ref(crate::DataEntity, crate::DerivedFromRelation).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::StringValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -54,7 +54,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::DataEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "validation" => Field::<ValidationRelation, value::AnyValue>::parse,
         "key_schema" => Field::<KeySchemaRelation, V::SchemaDefinition>::parse,
@@ -109,7 +109,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::DataEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "default" => Field::<DefaultRelation, value::BoolValue>::parse,
         "status" => Field::<DefaultRelation, StatusValue>::parse,
@@ -131,7 +131,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::DataEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "required" => Field::<RequiredRelation, value::BoolValue>::parse,
         "default" => Field::<DefaultRelation, value::AnyValue>::parse,
@@ -156,7 +156,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::DataEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::DataEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "required" => Field::<RequiredRelation, value::BoolValue>::parse,
         "default" => Field::<DefaultRelation, value::AnyValue>::parse,
@@ -199,7 +199,7 @@ where
         toto_yaml::as_map(n, ast)
             .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(data, items, ast))
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(data, n, ast);
+                FieldRef::type_ref(crate::DataEntity, crate::HasTypeRelation).link(data, n, ast);
                 data
             }))
             .or_else(|| {

--- a/crates/toto_tosca/src/grammar/v2_0/data.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/data.rs
@@ -5,9 +5,9 @@ use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser};
 use crate::{
     grammar::{collection::Collection, field::Field, field_ref::FieldRef, ToscaDefinitionsVersion},
     DefaultRelation, DefinitionRelation, DescriptionRelation, EntrySchemaRelation,
-    ExternalSchemaRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
-    RefDerivedFromRelation, RefHasTypeRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
+    ExternalSchemaRelation, KeySchemaRelation, MappingRelation, MetadataRelation, RequiredRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation, ValueRelation,
+    VersionRelation,
 };
 
 use super::value;
@@ -195,16 +195,12 @@ where
         n: toto_ast::GraphHandle,
         ast: &mut toto_ast::AST<E, R>,
     ) -> Option<toto_ast::GraphHandle> {
-        let import = add_with_loc(crate::Entity::from(crate::DataEntity), n, ast);
+        let data = add_with_loc(crate::Entity::from(crate::DataEntity), n, ast);
         toto_yaml::as_map(n, ast)
-            .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(import, items, ast))
+            .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(data, items, ast))
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                ast.add_edge(
-                    import,
-                    n,
-                    crate::Relation::from(crate::RefHasTypeRelation).into(),
-                );
-                import
+                FieldRef::has_type(crate::Entity::from(crate::DataEntity)).parse(data, n, ast);
+                data
             }))
             .or_else(|| {
                 add_with_loc(
@@ -214,7 +210,7 @@ where
                 );
                 None
             });
-        Some(import)
+        Some(data)
     }
 }
 

--- a/crates/toto_tosca/src/grammar/v2_0/function.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/function.rs
@@ -1,11 +1,12 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{mandatory, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser};
 
 use crate::{
     grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
     DefinitionRelation, DescriptionRelation, FunctionArgumentRelation,
-    FunctionOptionalArgumentRelation, FunctionSignatureRelation, MetadataRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    FunctionOptionalArgumentRelation, FunctionSignatureRelation, MetadataRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/function.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/function.rs
@@ -1,18 +1,11 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser, Schema};
 
 use crate::{
     grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
-    EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, FunctionArgumentRelation,
-    FunctionOptionalArgumentRelation, FunctionSignatureRelation, KeySchemaRelation,
-    MappingRelation, MetadataRelation, MimeTypeRelation, PrimaryArtifactRelation,
-    RefHasFileRelation, RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation,
-    RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation, RepositoryRelation,
-    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
-    ValueRelation, VersionRelation,
+    DefinitionRelation, DescriptionRelation, FunctionArgumentRelation,
+    FunctionOptionalArgumentRelation, FunctionSignatureRelation, MetadataRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/function.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/function.rs
@@ -9,10 +9,10 @@ use crate::{
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, FunctionArgumentRelation,
     FunctionOptionalArgumentRelation, FunctionSignatureRelation, KeySchemaRelation,
     MappingRelation, MetadataRelation, MimeTypeRelation, PrimaryArtifactRelation,
-    RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation, RefMemberNodeTemplateRelation,
-    RefMemberNodeTypeRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
-    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
-    ValidationRelation, ValueRelation, VersionRelation,
+    RefHasFileRelation, RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation,
+    RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation, RepositoryRelation,
+    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
+    ValueRelation, VersionRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/group.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/group.rs
@@ -1,14 +1,15 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{mandatory, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser};
 
 use crate::{
     grammar::{
         collection::Collection, field::Field, field_ref::FieldRef, list::List,
         ToscaDefinitionsVersion,
     },
-    AssignmentRelation,
-    DefinitionRelation, DescriptionRelation, MetadataRelation, RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
+    AssignmentRelation, DefinitionRelation, DescriptionRelation, MemberNodeTemplateRelation,
+    MemberNodeTypeRelation, MetadataRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    VersionRelation,
 };
 
 use super::value;
@@ -27,13 +28,13 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::GroupEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::GroupEntity)).parse(r, n, ast),
+        "derived_from" => |r, n, ast| FieldRef::type_ref(crate::GroupEntity, crate::DerivedFromRelation).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "properties" => Collection::<DefinitionRelation, V::PropertyDefinition>::parse,
         "attributes" => Collection::<DefinitionRelation, V::AttributeDefinition>::parse,
-        "members" => List::<RefMemberNodeTypeRelation, value::StringValue>::parse,
+        "members" => List::<MemberNodeTypeRelation, value::StringValue>::parse,
     };
 }
 
@@ -45,12 +46,12 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::GroupEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::GroupEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::GroupEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,
         "attributes" => Collection::<AssignmentRelation, value::AnyValue>::parse,
-        "members" => List::<RefMemberNodeTemplateRelation, value::StringValue>::parse,
+        "members" => List::<MemberNodeTemplateRelation, value::StringValue>::parse,
     };
 
     const VALIDATION: &'static [toto_parser::ValidationFieldFn] =

--- a/crates/toto_tosca/src/grammar/v2_0/group.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/group.rs
@@ -1,20 +1,14 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser, Schema};
 
 use crate::{
     grammar::{
         collection::Collection, field::Field, field_ref::FieldRef, list::List,
         ToscaDefinitionsVersion,
     },
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
-    EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
-    MappingRelation, MetadataRelation, MimeTypeRelation, PrimaryArtifactRelation,
-    RefHasFileRelation, RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation,
-    RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation, RepositoryRelation,
-    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
-    ValueRelation, VersionRelation,
+    AssignmentRelation,
+    DefinitionRelation, DescriptionRelation, MetadataRelation, RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/group.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/group.rs
@@ -11,10 +11,10 @@ use crate::{
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
     MappingRelation, MetadataRelation, MimeTypeRelation, PrimaryArtifactRelation,
-    RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation, RefMemberNodeTemplateRelation,
-    RefMemberNodeTypeRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
-    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
-    ValidationRelation, ValueRelation, VersionRelation,
+    RefHasFileRelation, RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation,
+    RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation, RepositoryRelation,
+    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
+    ValueRelation, VersionRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/group.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/group.rs
@@ -3,7 +3,10 @@ use std::{collections::HashSet, marker::PhantomData};
 use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
+    grammar::{
+        collection::Collection, field::Field, field_ref::FieldRef, list::List,
+        ToscaDefinitionsVersion,
+    },
     AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
@@ -30,7 +33,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::GroupEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => Field::<RefDerivedFromRelation, value::StringValue>::parse,
+        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::GroupEntity)).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -48,7 +51,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::GroupEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::GroupEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/import.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/import.rs
@@ -22,6 +22,7 @@ where
     const SELF: fn() -> E = || crate::Entity::from(crate::ImportEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
         "url" => Field::<ImportUrlRelation, value::StringValue>::parse,
+
         "profile" => Field::<ImportProfileRelation, value::StringValue>::parse,
         "repository" => Field::<ImportRepositoryRelation, value::StringValue>::parse,
         "namespace" => Field::<ImportNamespaceRelation, value::StringValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/interface.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/interface.rs
@@ -1,21 +1,17 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser, Schema};
 
 use crate::{
     grammar::{
-        collection::Collection, field::Field, field_ref::FieldRef, list::List,
+        collection::Collection, field::Field, field_ref::FieldRef,
         ToscaDefinitionsVersion,
     },
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, EntrySchemaRelation,
-    ExternalSchemaRelation, FileExtRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
-    MimeTypeRelation, PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation,
-    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
-    ValueRelation, VersionRelation,
+    AssignmentRelation,
+    DefinitionRelation, DescriptionRelation, MetadataRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
 };
 
-use super::{value, ImplementationDefinition};
+use super::{value};
 
 #[derive(Debug)]
 pub struct InterfaceTypeDefinition<V: ToscaDefinitionsVersion>(PhantomData<V>);

--- a/crates/toto_tosca/src/grammar/v2_0/interface.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/interface.rs
@@ -1,17 +1,14 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{mandatory, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser};
 
 use crate::{
-    grammar::{
-        collection::Collection, field::Field, field_ref::FieldRef,
-        ToscaDefinitionsVersion,
-    },
-    AssignmentRelation,
-    DefinitionRelation, DescriptionRelation, MetadataRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
+    grammar::{collection::Collection, field::Field, field_ref::FieldRef, ToscaDefinitionsVersion},
+    AssignmentRelation, DefinitionRelation, DescriptionRelation, MetadataRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
 };
 
-use super::{value};
+use super::value;
 
 #[derive(Debug)]
 pub struct InterfaceTypeDefinition<V: ToscaDefinitionsVersion>(PhantomData<V>);
@@ -30,7 +27,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::InterfaceEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::InterfaceEntity)).parse(r, n, ast),
+        "derived_from" => |r, n, ast| FieldRef::type_ref(crate::InterfaceEntity, crate::DerivedFromRelation).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -48,7 +45,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::InterfaceEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::InterfaceEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::InterfaceEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "operations" => Collection::<DefinitionRelation, V::OperationDefinition>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/interface.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/interface.rs
@@ -10,9 +10,9 @@ use crate::{
     AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, EntrySchemaRelation,
     ExternalSchemaRelation, FileExtRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
-    MimeTypeRelation, PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation,
-    RefHasTypeRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
+    MimeTypeRelation, PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation,
+    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
+    ValueRelation, VersionRelation,
 };
 
 use super::{value, ImplementationDefinition};

--- a/crates/toto_tosca/src/grammar/v2_0/interface.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/interface.rs
@@ -3,7 +3,10 @@ use std::{collections::HashSet, marker::PhantomData};
 use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
+    grammar::{
+        collection::Collection, field::Field, field_ref::FieldRef, list::List,
+        ToscaDefinitionsVersion,
+    },
     AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, EntrySchemaRelation,
     ExternalSchemaRelation, FileExtRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
@@ -31,7 +34,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::InterfaceEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => Field::<RefDerivedFromRelation, value::StringValue>::parse,
+        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::InterfaceEntity)).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -49,7 +52,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::InterfaceEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::InterfaceEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "operations" => Collection::<DefinitionRelation, V::OperationDefinition>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/node.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/node.rs
@@ -4,6 +4,7 @@ use crate::{
     grammar::{
         collection::Collection,
         field::Field,
+        field_ref::FieldRef,
         list::{KeyedList, List},
         ToscaDefinitionsVersion,
     },
@@ -29,7 +30,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::NodeEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => Field::<RefDerivedFromRelation, value::StringValue>::parse,
+        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::NodeEntity)).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -50,7 +51,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::NodeEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::NodeEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "directives" => List::<DirectiveRelation, value::StringValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/node.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/node.rs
@@ -30,7 +30,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::NodeEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::NodeEntity)).parse(r, n, ast),
+        "derived_from" => |r, n, ast| FieldRef::type_ref(crate::NodeEntity, crate::DerivedFromRelation).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -51,7 +51,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::NodeEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::NodeEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::NodeEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "directives" => List::<DirectiveRelation, value::StringValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/node.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/node.rs
@@ -9,8 +9,8 @@ use crate::{
         ToscaDefinitionsVersion,
     },
     AssignmentRelation, DefinitionRelation, DescriptionRelation, DirectiveRelation,
-    MetadataRelation, OrderedAssignmentRelation, OrderedDefinitionRelation, RefDerivedFromRelation,
-    RefHasTypeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
+    MetadataRelation, OrderedAssignmentRelation, OrderedDefinitionRelation, ToscaCompatibleEntity,
+    ToscaCompatibleRelation, VersionRelation,
 };
 use toto_parser::RelationParser;
 

--- a/crates/toto_tosca/src/grammar/v2_0/notification.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/notification.rs
@@ -1,11 +1,11 @@
-use std::{marker::PhantomData};
+use std::marker::PhantomData;
 
-use toto_parser::{RelationParser, Schema};
+use toto_parser::RelationParser;
 
 use crate::{
     grammar::{collection::Collection, field::Field, ToscaDefinitionsVersion},
-    AssignmentRelation,
-    DefinitionRelation, DescriptionRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    AssignmentRelation, DefinitionRelation, DescriptionRelation, ToscaCompatibleEntity,
+    ToscaCompatibleRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/notification.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/notification.rs
@@ -1,15 +1,11 @@
-use std::{collections::HashSet, marker::PhantomData};
+use std::{marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{RelationParser, Schema};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, EntrySchemaRelation,
-    ExternalSchemaRelation, FileExtRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
-    MimeTypeRelation, PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation,
-    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
-    ValueRelation, VersionRelation,
+    grammar::{collection::Collection, field::Field, ToscaDefinitionsVersion},
+    AssignmentRelation,
+    DefinitionRelation, DescriptionRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/notification.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/notification.rs
@@ -7,9 +7,9 @@ use crate::{
     AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, EntrySchemaRelation,
     ExternalSchemaRelation, FileExtRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
-    MimeTypeRelation, PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation,
-    RefHasTypeRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
+    MimeTypeRelation, PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation,
+    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
+    ValueRelation, VersionRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/operation.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/operation.rs
@@ -1,14 +1,14 @@
-use std::{marker::PhantomData};
+use std::marker::PhantomData;
 
-use toto_parser::{RelationParser, Schema};
+use toto_parser::RelationParser;
 
 use crate::{
     grammar::{collection::Collection, field::Field, ToscaDefinitionsVersion},
-    AssignmentRelation,
-    DefinitionRelation, DescriptionRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    AssignmentRelation, DefinitionRelation, DescriptionRelation, ToscaCompatibleEntity,
+    ToscaCompatibleRelation,
 };
 
-use super::{value};
+use super::value;
 
 #[derive(Debug)]
 pub struct OperationDefinition<V: ToscaDefinitionsVersion>(PhantomData<V>);

--- a/crates/toto_tosca/src/grammar/v2_0/operation.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/operation.rs
@@ -7,9 +7,9 @@ use crate::{
     AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, EntrySchemaRelation,
     ExternalSchemaRelation, FileExtRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
-    MimeTypeRelation, PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation,
-    RefHasTypeRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
+    MimeTypeRelation, PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation,
+    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
+    ValueRelation, VersionRelation,
 };
 
 use super::{value, ImplementationDefinition};

--- a/crates/toto_tosca/src/grammar/v2_0/operation.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/operation.rs
@@ -1,18 +1,14 @@
-use std::{collections::HashSet, marker::PhantomData};
+use std::{marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{RelationParser, Schema};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, EntrySchemaRelation,
-    ExternalSchemaRelation, FileExtRelation, KeySchemaRelation, MappingRelation, MetadataRelation,
-    MimeTypeRelation, PrimaryArtifactRelation, RefHasFileRelation, RepositoryRelation,
-    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
-    ValueRelation, VersionRelation,
+    grammar::{collection::Collection, field::Field, ToscaDefinitionsVersion},
+    AssignmentRelation,
+    DefinitionRelation, DescriptionRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
 };
 
-use super::{value, ImplementationDefinition};
+use super::{value};
 
 #[derive(Debug)]
 pub struct OperationDefinition<V: ToscaDefinitionsVersion>(PhantomData<V>);

--- a/crates/toto_tosca/src/grammar/v2_0/policy.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/policy.rs
@@ -1,20 +1,16 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser, Schema};
 
 use crate::{
     grammar::{
         collection::Collection, field::Field, field_ref::FieldRef, list::List,
         ToscaDefinitionsVersion,
     },
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
-    EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
-    MappingRelation, MetadataRelation, MimeTypeRelation, PolicyTriggerEventRelation,
-    PrimaryArtifactRelation, RefHasFileRelation, RefMemberNodeTemplateRelation,
-    RefMemberNodeTypeRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
-    RefValidTargetNodeTypeRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
+    AssignmentRelation,
+    DefinitionRelation, DescriptionRelation, MetadataRelation, PolicyTriggerEventRelation,
+    RefValidTargetNodeTypeRelation, ToscaCompatibleEntity,
+    ToscaCompatibleRelation, VersionRelation,
     WorkflowActivityRelation,
 };
 

--- a/crates/toto_tosca/src/grammar/v2_0/policy.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/policy.rs
@@ -11,11 +11,11 @@ use crate::{
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
     MappingRelation, MetadataRelation, MimeTypeRelation, PolicyTriggerEventRelation,
-    PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation,
-    RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation, RefValidRelationshipTypeRelation,
-    RefValidSourceNodeTypeRelation, RefValidTargetNodeTypeRelation, RepositoryRelation,
-    RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, ValidationRelation,
-    ValueRelation, VersionRelation, WorkflowActivityRelation,
+    PrimaryArtifactRelation, RefHasFileRelation, RefMemberNodeTemplateRelation,
+    RefMemberNodeTypeRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
+    RefValidTargetNodeTypeRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
+    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
+    WorkflowActivityRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/policy.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/policy.rs
@@ -1,17 +1,15 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{mandatory, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser};
 
 use crate::{
     grammar::{
         collection::Collection, field::Field, field_ref::FieldRef, list::List,
         ToscaDefinitionsVersion,
     },
-    AssignmentRelation,
-    DefinitionRelation, DescriptionRelation, MetadataRelation, PolicyTriggerEventRelation,
-    RefValidTargetNodeTypeRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, VersionRelation,
-    WorkflowActivityRelation,
+    AssignmentRelation, DefinitionRelation, DescriptionRelation, MetadataRelation,
+    PolicyTriggerEventRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    ValidTargetNodeTypeRelation, VersionRelation, WorkflowActivityRelation,
 };
 
 use super::value;
@@ -53,12 +51,12 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::PolicyEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::PolicyEntity)).parse(r, n, ast),
+        "derived_from" => |r, n, ast| FieldRef::type_ref(crate::PolicyEntity, crate::DerivedFromRelation).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "properties" => Collection::<DefinitionRelation, V::PropertyDefinition>::parse,
-        "targets" => List::<RefValidTargetNodeTypeRelation, value::StringValue>::parse,
+        "targets" => List::<ValidTargetNodeTypeRelation, value::StringValue>::parse,
         "triggers" => Collection::<DefinitionRelation, V::PolicyTriggerDefinition>::parse,
     };
 }
@@ -71,12 +69,12 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::PolicyEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::PolicyEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::PolicyEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,
         // todo: target nodes and groups
-        "targets" => List::<RefValidTargetNodeTypeRelation, value::StringValue>::parse,
+        "targets" => List::<ValidTargetNodeTypeRelation, value::StringValue>::parse,
         "triggers" => Collection::<DefinitionRelation, V::PolicyTriggerDefinition>::parse,
     };
 

--- a/crates/toto_tosca/src/grammar/v2_0/policy.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/policy.rs
@@ -3,7 +3,10 @@ use std::{collections::HashSet, marker::PhantomData};
 use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
+    grammar::{
+        collection::Collection, field::Field, field_ref::FieldRef, list::List,
+        ToscaDefinitionsVersion,
+    },
     AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
@@ -54,7 +57,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::PolicyEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => Field::<RefDerivedFromRelation, value::StringValue>::parse,
+        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::PolicyEntity)).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -72,7 +75,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::PolicyEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::PolicyEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/relationship.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/relationship.rs
@@ -6,9 +6,8 @@ use crate::{
         ToscaDefinitionsVersion,
     },
     AssignmentRelation, DefinitionRelation, DescriptionRelation, MetadataRelation,
-    RefDerivedFromRelation, RefHasTypeRelation, RefValidCapabilityTypeRelation,
-    RefValidSourceNodeTypeRelation, RefValidTargetNodeTypeRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, VersionRelation,
+    RefValidCapabilityTypeRelation, RefValidSourceNodeTypeRelation, RefValidTargetNodeTypeRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
 };
 use toto_parser::{add_with_loc, mandatory, RelationParser};
 
@@ -145,11 +144,8 @@ where
         toto_yaml::as_map(n, ast)
             .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(rel, items, ast))
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                ast.add_edge(
-                    rel,
-                    n,
-                    crate::Relation::from(crate::RefHasTypeRelation).into(),
-                );
+                FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity))
+                    .parse(rel, n, ast);
                 rel
             }))
             .or_else(|| {
@@ -178,11 +174,8 @@ where
         toto_yaml::as_map(n, ast)
             .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(rel, items, ast))
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                ast.add_edge(
-                    rel,
-                    n,
-                    crate::Relation::from(crate::RefHasTypeRelation).into(),
-                );
+                FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity))
+                    .parse(rel, n, ast);
                 rel
             }))
             .or_else(|| {

--- a/crates/toto_tosca/src/grammar/v2_0/relationship.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/relationship.rs
@@ -6,8 +6,8 @@ use crate::{
         ToscaDefinitionsVersion,
     },
     AssignmentRelation, DefinitionRelation, DescriptionRelation, MetadataRelation,
-    RefValidCapabilityTypeRelation, RefValidSourceNodeTypeRelation, RefValidTargetNodeTypeRelation,
-    ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation, ValidCapabilityTypeRelation,
+    ValidSourceNodeTypeRelation, ValidTargetNodeTypeRelation, VersionRelation,
 };
 use toto_parser::{add_with_loc, mandatory, RelationParser};
 
@@ -33,16 +33,16 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RelationshipEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::RelationshipEntity)).parse(r, n, ast),
+        "derived_from" => |r, n, ast| FieldRef::type_ref(crate::RelationshipEntity, crate::DerivedFromRelation).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "properties" => Collection::<DefinitionRelation, V::PropertyDefinition>::parse,
         "attributes" => Collection::<DefinitionRelation, V::AttributeDefinition>::parse,
         "interfaces" => Collection::<DefinitionRelation, V::InterfaceDefinition>::parse,
-        "valid_capability_types" => List::<RefValidCapabilityTypeRelation, value::StringValue>::parse,
-        "valid_target_node_types" => List::<RefValidTargetNodeTypeRelation, value::StringValue>::parse,
-        "valid_source_node_types" => List::<RefValidSourceNodeTypeRelation, value::StringValue>::parse,
+        "valid_capability_types" => List::<ValidCapabilityTypeRelation, value::StringValue>::parse,
+        "valid_target_node_types" => List::<ValidTargetNodeTypeRelation, value::StringValue>::parse,
+        "valid_source_node_types" => List::<ValidSourceNodeTypeRelation, value::StringValue>::parse,
     };
 }
 
@@ -54,7 +54,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RelationshipEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::RelationshipEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,
@@ -75,7 +75,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RelationshipEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::RelationshipEntity, crate::HasTypeRelation).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,
@@ -95,7 +95,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RelationshipEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity)).parse(r, n, ast),
+        "type" => |r, n, ast| FieldRef::type_ref(crate::RelationshipEntity, crate::HasTypeRelation).parse(r, n, ast),
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,
         "attributes" => Collection::<AssignmentRelation, value::AnyValue>::parse,
         "interfaces" => Collection::<AssignmentRelation, V::InterfaceAssignment>::parse,
@@ -144,8 +144,8 @@ where
         toto_yaml::as_map(n, ast)
             .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(rel, items, ast))
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity))
-                    .parse(rel, n, ast);
+                FieldRef::type_ref(crate::RelationshipEntity, crate::HasTypeRelation)
+                    .link(rel, n, ast);
                 rel
             }))
             .or_else(|| {
@@ -174,7 +174,7 @@ where
         toto_yaml::as_map(n, ast)
             .map(|items| <Self as toto_parser::Schema<E, R>>::parse_schema(rel, items, ast))
             .or(toto_yaml::as_string(n, ast).map(|_| ()).map(|_| {
-                FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity))
+                FieldRef::type_ref(crate::RelationshipEntity, crate::HasTypeRelation)
                     .parse(rel, n, ast);
                 rel
             }))

--- a/crates/toto_tosca/src/grammar/v2_0/relationship.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/relationship.rs
@@ -1,7 +1,10 @@
 use std::{collections::HashSet, marker::PhantomData};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
+    grammar::{
+        collection::Collection, field::Field, field_ref::FieldRef, list::List,
+        ToscaDefinitionsVersion,
+    },
     AssignmentRelation, DefinitionRelation, DescriptionRelation, MetadataRelation,
     RefDerivedFromRelation, RefHasTypeRelation, RefValidCapabilityTypeRelation,
     RefValidSourceNodeTypeRelation, RefValidTargetNodeTypeRelation, ToscaCompatibleEntity,
@@ -31,7 +34,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RelationshipEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "derived_from" => Field::<RefDerivedFromRelation, value::StringValue>::parse,
+        "derived_from" => |r, n, ast| FieldRef::derived_from(crate::Entity::from(crate::RelationshipEntity)).parse(r, n, ast),
         "version" => Field::<VersionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
@@ -52,7 +55,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RelationshipEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,
@@ -73,7 +76,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RelationshipEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity)).parse(r, n, ast),
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,
@@ -93,7 +96,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RelationshipEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "type" => |r, n, ast| FieldRef::has_type(crate::Entity::from(crate::RelationshipEntity)).parse(r, n, ast),
         "properties" => Collection::<AssignmentRelation, value::AnyValue>::parse,
         "attributes" => Collection::<AssignmentRelation, value::AnyValue>::parse,
         "interfaces" => Collection::<AssignmentRelation, V::InterfaceAssignment>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/requirement.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/requirement.rs
@@ -4,8 +4,8 @@ use crate::{
     grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
     AssignmentRelation, DefinitionRelation, DescriptionRelation, DirectiveRelation,
     MetadataRelation, RefTargetCapabilityRelation, RefTargetNodeRelation,
-    RefValidCapabilityTypeRelation, RefValidSourceNodeTypeRelation, RefValidTargetNodeTypeRelation,
-    ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
+    RefValidCapabilityTypeRelation, RefValidTargetNodeTypeRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation,
 };
 use toto_parser::{add_with_loc, mandatory, RelationParser};
 

--- a/crates/toto_tosca/src/grammar/v2_0/requirement.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/requirement.rs
@@ -3,10 +3,9 @@ use std::{collections::HashSet, marker::PhantomData};
 use crate::{
     grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
     AssignmentRelation, DefinitionRelation, DescriptionRelation, DirectiveRelation,
-    MetadataRelation, RefDerivedFromRelation, RefHasTypeRelation, RefTargetCapabilityRelation,
-    RefTargetNodeRelation, RefValidCapabilityTypeRelation, RefValidSourceNodeTypeRelation,
-    RefValidTargetNodeTypeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
-    VersionRelation,
+    MetadataRelation, RefTargetCapabilityRelation, RefTargetNodeRelation,
+    RefValidCapabilityTypeRelation, RefValidSourceNodeTypeRelation, RefValidTargetNodeTypeRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation, VersionRelation,
 };
 use toto_parser::{add_with_loc, mandatory, RelationParser};
 

--- a/crates/toto_tosca/src/grammar/v2_0/requirement.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/requirement.rs
@@ -1,10 +1,13 @@
 use std::{collections::HashSet, marker::PhantomData};
 
 use crate::{
-    grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
+    grammar::{
+        collection::Collection, field::Field, field_ref::FieldRef, list::List,
+        ToscaDefinitionsVersion,
+    },
     AssignmentRelation, DefinitionRelation, DescriptionRelation, DirectiveRelation,
     MetadataRelation, TargetCapabilityRelation, TargetNodeRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidCapabilityTypeRelation, ValidTargetNodeTypeRelation,
+    ToscaCompatibleRelation,
 };
 use toto_parser::{add_with_loc, mandatory, RelationParser};
 
@@ -27,8 +30,8 @@ where
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "relationship" => Field::<DefinitionRelation, V::RelationshipDefinition>::parse,
-        "node" => Field::<ValidTargetNodeTypeRelation, value::StringValue>::parse,
-        "capability" => Field::<ValidCapabilityTypeRelation, value::StringValue>::parse,
+        "node" => |r, n, ast| FieldRef::type_ref(crate::NodeEntity, crate::ValidTargetNodeTypeRelation).parse(r, n, ast),
+        "capability" => |r, n, ast| FieldRef::type_ref(crate::CapabilityEntity, crate::ValidCapabilityTypeRelation).parse(r, n, ast),
         "node_filter" => |_, _, _| {},
         "count_range" => |_, _, _| {},
     };
@@ -45,7 +48,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RequirementEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "node" => Field::<TargetNodeRelation, value::StringValue>::parse,
+        "node" => |r, n, ast| FieldRef::def_ref(crate::NodeEntity, crate::TargetNodeRelation).parse(r, n, ast),
         "capability" => Field::<TargetCapabilityRelation, value::StringValue>::parse,
         "relationship" => Field::<AssignmentRelation, V::RelationshipAssignment>::parse,
         "allocation" => |_, _, _| {},

--- a/crates/toto_tosca/src/grammar/v2_0/requirement.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/requirement.rs
@@ -3,9 +3,8 @@ use std::{collections::HashSet, marker::PhantomData};
 use crate::{
     grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
     AssignmentRelation, DefinitionRelation, DescriptionRelation, DirectiveRelation,
-    MetadataRelation, RefTargetCapabilityRelation, RefTargetNodeRelation,
-    RefValidCapabilityTypeRelation, RefValidTargetNodeTypeRelation,
-    ToscaCompatibleEntity, ToscaCompatibleRelation,
+    MetadataRelation, TargetCapabilityRelation, TargetNodeRelation, ToscaCompatibleEntity,
+    ToscaCompatibleRelation, ValidCapabilityTypeRelation, ValidTargetNodeTypeRelation,
 };
 use toto_parser::{add_with_loc, mandatory, RelationParser};
 
@@ -28,8 +27,8 @@ where
         "description" => Field::<DescriptionRelation, value::StringValue>::parse,
         "metadata" => Collection::<MetadataRelation, value::AnyValue>::parse,
         "relationship" => Field::<DefinitionRelation, V::RelationshipDefinition>::parse,
-        "node" => Field::<RefValidTargetNodeTypeRelation, value::StringValue>::parse,
-        "capability" => Field::<RefValidCapabilityTypeRelation, value::StringValue>::parse,
+        "node" => Field::<ValidTargetNodeTypeRelation, value::StringValue>::parse,
+        "capability" => Field::<ValidCapabilityTypeRelation, value::StringValue>::parse,
         "node_filter" => |_, _, _| {},
         "count_range" => |_, _, _| {},
     };
@@ -46,8 +45,8 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::RequirementEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "node" => Field::<RefTargetNodeRelation, value::StringValue>::parse,
-        "capability" => Field::<RefTargetCapabilityRelation, value::StringValue>::parse,
+        "node" => Field::<TargetNodeRelation, value::StringValue>::parse,
+        "capability" => Field::<TargetCapabilityRelation, value::StringValue>::parse,
         "relationship" => Field::<AssignmentRelation, V::RelationshipAssignment>::parse,
         "allocation" => |_, _, _| {},
         "count" => |_, _, _| {},
@@ -88,7 +87,7 @@ where
                 ast.add_edge(
                     req,
                     n,
-                    crate::Relation::from(crate::RefTargetNodeRelation).into(),
+                    crate::Relation::from(crate::TargetNodeRelation).into(),
                 );
                 req
             }))

--- a/crates/toto_tosca/src/grammar/v2_0/substitution_mapping.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/substitution_mapping.rs
@@ -1,23 +1,15 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, ParseError, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser, Schema};
 
 use crate::{
     grammar::{
         collection::Collection,
-        field::Field,
         field_ref::FieldRef,
-        list::{KeyedList, List},
+        list::{KeyedList},
         ToscaDefinitionsVersion,
     },
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
-    EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
-    MappingRelation, MetadataRelation, MimeTypeRelation, OrderedDefinitionRelation,
-    PrimaryArtifactRelation, RefHasFileRelation, RefMemberNodeTemplateRelation,
-    RefMemberNodeTypeRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
-    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
-    ValidationRelation, ValueRelation, VersionRelation,
+    DefinitionRelation, OrderedDefinitionRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/substitution_mapping.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/substitution_mapping.rs
@@ -6,6 +6,7 @@ use crate::{
     grammar::{
         collection::Collection,
         field::Field,
+        field_ref::FieldRef,
         list::{KeyedList, List},
         ToscaDefinitionsVersion,
     },
@@ -13,10 +14,10 @@ use crate::{
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
     MappingRelation, MetadataRelation, MimeTypeRelation, OrderedDefinitionRelation,
-    PrimaryArtifactRelation, RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation,
-    RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation, RefValidRelationshipTypeRelation,
-    RefValidSourceNodeTypeRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
+    PrimaryArtifactRelation, RefHasFileRelation, RefMemberNodeTemplateRelation,
+    RefMemberNodeTypeRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
+    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    ValidationRelation, ValueRelation, VersionRelation,
 };
 
 use super::value;
@@ -32,7 +33,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::SubstitutionMappingEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "node_type" => Field::<RefHasTypeRelation, value::StringValue>::parse,
+        "node_type" => |r, n, ast| FieldRef::substitutes_type(crate::Entity::from(crate::NodeEntity)).parse(r, n, ast),
         "substitution_filter" => |_, _, _| {},
         "properties" => Collection::<DefinitionRelation, value::AnyValue>::parse,
         "attributes" => Collection::<DefinitionRelation, value::AnyValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/substitution_mapping.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/substitution_mapping.rs
@@ -1,13 +1,10 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{mandatory, RelationParser, Schema};
+use toto_parser::{mandatory, RelationParser};
 
 use crate::{
     grammar::{
-        collection::Collection,
-        field_ref::FieldRef,
-        list::{KeyedList},
-        ToscaDefinitionsVersion,
+        collection::Collection, field_ref::FieldRef, list::KeyedList, ToscaDefinitionsVersion,
     },
     DefinitionRelation, OrderedDefinitionRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
 };
@@ -25,7 +22,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::SubstitutionMappingEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "node_type" => |r, n, ast| FieldRef::substitutes_type(crate::Entity::from(crate::NodeEntity)).parse(r, n, ast),
+        "node_type" => |r, n, ast| FieldRef::type_ref(crate::NodeEntity, crate::SubstitutesTypeRelation).parse(r, n, ast),
         "substitution_filter" => |_, _, _| {},
         "properties" => Collection::<DefinitionRelation, value::AnyValue>::parse,
         "attributes" => Collection::<DefinitionRelation, value::AnyValue>::parse,

--- a/crates/toto_tosca/src/grammar/v2_0/workflow.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/workflow.rs
@@ -8,11 +8,10 @@ use crate::{
     DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
     EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
     MappingRelation, MetadataRelation, MimeTypeRelation, PrimaryArtifactRelation,
-    RefDerivedFromRelation, RefHasFileRelation, RefHasTypeRelation, RefMemberNodeTemplateRelation,
-    RefMemberNodeTypeRelation, RefTargetNodeRelation, RefValidRelationshipTypeRelation,
-    RefValidSourceNodeTypeRelation, RepositoryRelation, RequiredRelation, ToscaCompatibleEntity,
-    ToscaCompatibleRelation, ValidationRelation, ValueRelation, VersionRelation,
-    WorkflowActivityRelation,
+    RefHasFileRelation, RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation,
+    RefTargetNodeRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
+    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
+    ValidationRelation, ValueRelation, VersionRelation, WorkflowActivityRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/grammar/v2_0/workflow.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/workflow.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashSet, marker::PhantomData};
 
-use toto_parser::{add_with_loc, mandatory, EntityParser, ParseError, RelationParser, Schema};
+use toto_parser::{add_with_loc, mandatory, EntityParser, ParseError, RelationParser};
 
 use crate::{
     grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
-    DefinitionRelation, DescriptionRelation, MetadataRelation,
-    RefTargetNodeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, WorkflowActivityRelation,
+    DefinitionRelation, DescriptionRelation, MetadataRelation, TargetNodeRelation,
+    ToscaCompatibleEntity, ToscaCompatibleRelation, WorkflowActivityRelation,
 };
 
 use super::value;
@@ -78,7 +78,7 @@ where
 {
     const SELF: fn() -> E = || crate::Entity::from(crate::WorkflowStepEntity).into();
     const SCHEMA: toto_parser::StaticSchemaMap<E, R> = phf::phf_map! {
-        "target" => Field::<RefTargetNodeRelation, value::StringValue>::parse,
+        "target" => Field::<TargetNodeRelation, value::StringValue>::parse,
         "target_relationship" => Field::<DefinitionRelation, value::StringValue>::parse,
         "filter" => |_, _, _| {},
         "activities" => List::<WorkflowActivityRelation, V::WorkflowActivityDefinition>::parse,
@@ -190,7 +190,7 @@ where
                 ast.add_edge(
                     activity,
                     n,
-                    crate::Relation::from(crate::RefWorkflowRelation).into(),
+                    crate::Relation::from(crate::WorkflowRelation).into(),
                 );
                 activity
             }))
@@ -227,7 +227,7 @@ where
                 ast.add_edge(
                     activity,
                     n,
-                    crate::Relation::from(crate::RefWorkflowRelation).into(),
+                    crate::Relation::from(crate::WorkflowRelation).into(),
                 );
                 activity
             }))
@@ -264,7 +264,7 @@ where
                 ast.add_edge(
                     activity,
                     n,
-                    crate::Relation::from(crate::RefOperationRelation).into(),
+                    crate::Relation::from(crate::OperationRelation).into(),
                 );
                 activity
             }))

--- a/crates/toto_tosca/src/grammar/v2_0/workflow.rs
+++ b/crates/toto_tosca/src/grammar/v2_0/workflow.rs
@@ -4,14 +4,8 @@ use toto_parser::{add_with_loc, mandatory, EntityParser, ParseError, RelationPar
 
 use crate::{
     grammar::{collection::Collection, field::Field, list::List, ToscaDefinitionsVersion},
-    AssignmentRelation, ChecksumAlgorithmRelation, ChecksumRelation, DefaultRelation,
-    DefinitionRelation, DependencyArtifactRelation, DescriptionRelation, DirectiveRelation,
-    EntrySchemaRelation, ExternalSchemaRelation, FileExtRelation, KeySchemaRelation,
-    MappingRelation, MetadataRelation, MimeTypeRelation, PrimaryArtifactRelation,
-    RefHasFileRelation, RefMemberNodeTemplateRelation, RefMemberNodeTypeRelation,
-    RefTargetNodeRelation, RefValidRelationshipTypeRelation, RefValidSourceNodeTypeRelation,
-    RepositoryRelation, RequiredRelation, ToscaCompatibleEntity, ToscaCompatibleRelation,
-    ValidationRelation, ValueRelation, VersionRelation, WorkflowActivityRelation,
+    DefinitionRelation, DescriptionRelation, MetadataRelation,
+    RefTargetNodeRelation, ToscaCompatibleEntity, ToscaCompatibleRelation, WorkflowActivityRelation,
 };
 
 use super::value;

--- a/crates/toto_tosca/src/lib.rs
+++ b/crates/toto_tosca/src/lib.rs
@@ -54,8 +54,7 @@ impl ToscaParser {
                 });
             });
 
-        let lookup = Lookup::from_ast(ast);
-        lookup.lookup(ast);
+        Lookup::lookup(ast);
 
         file_handle
     }

--- a/crates/toto_tosca/src/models.rs
+++ b/crates/toto_tosca/src/models.rs
@@ -2,6 +2,8 @@ extern crate derive_more;
 
 use derive_more::{From, TryInto};
 
+use crate::semantic::SimpleLookuper;
+
 #[derive(Debug)]
 pub struct Version {
     pub minor: u64,
@@ -145,6 +147,11 @@ pub enum Entity {
     FunctionSignature(FunctionSignatureEntity),
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct RefRelation {
+    pub lookuper: Box<SimpleLookuper>,
+}
+
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct ToscaDefinitionsVersionRelation;
 
@@ -283,6 +290,9 @@ pub struct RefMemberNodeTypeRelation(pub usize);
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
 pub struct RefMemberNodeTemplateRelation(pub usize);
 
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
+pub struct MemberNodeTemplateRelation(pub usize);
+
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
 pub struct RefValidRelationshipTypeRelation(pub usize);
 
@@ -297,6 +307,9 @@ pub struct RefValidTargetNodeTypeRelation(pub usize);
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct RefTargetNodeRelation;
+
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
+pub struct TargetNodeRelation;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct RefTargetCapabilityRelation;
@@ -325,6 +338,8 @@ pub struct FunctionSignatureRelation(pub usize);
 #[derive(Debug, PartialEq, Eq, Hash, Clone, From, TryInto)]
 #[try_into(owned, ref, ref_mut)]
 pub enum Relation {
+    Ref(RefRelation),
+
     ToscaDefinitionsVersion(ToscaDefinitionsVersionRelation),
     ServiceTemplate(ServiceTemplateRelation),
     Repository(RepositoryRelation),
@@ -384,12 +399,14 @@ pub enum Relation {
     Directive(DirectiveRelation),
 
     RefMemberNodeTemplate(RefMemberNodeTemplateRelation),
+    MemberNodeTemplate(MemberNodeTemplateRelation),
     RefMemberNodeType(RefMemberNodeTypeRelation),
 
     RefValidCapabilityType(RefValidCapabilityTypeRelation),
     RefValidTargetNodeType(RefValidTargetNodeTypeRelation),
 
     RefTargetNode(RefTargetNodeRelation),
+    TargetNode(TargetNodeRelation),
     RefTargetCapability(RefTargetCapabilityRelation),
 
     SubstitutionMapping(SubstitutionMappingRelation),

--- a/crates/toto_tosca/src/models.rs
+++ b/crates/toto_tosca/src/models.rs
@@ -246,7 +246,7 @@ pub struct KeySchemaRelation;
 pub struct EntrySchemaRelation;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
-pub struct RefRootRelation;
+pub struct RootRelation;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct HasTypeRelation;
@@ -376,7 +376,7 @@ pub enum Relation {
     KeySchema(KeySchemaRelation),
     EntrySchema(EntrySchemaRelation),
 
-    RefRoot(RefRootRelation),
+    Root(RootRelation),
 
     HasType(HasTypeRelation),
     RefHasType(RefHasTypeRelation),

--- a/crates/toto_tosca/src/models.rs
+++ b/crates/toto_tosca/src/models.rs
@@ -264,7 +264,7 @@ pub struct MimeTypeRelation;
 pub struct FileExtRelation(pub usize);
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
-pub struct RefHasFileRelation;
+pub struct HasFileRelation;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct ChecksumRelation;
@@ -279,46 +279,94 @@ pub struct PrimaryArtifactRelation;
 pub struct DependencyArtifactRelation(pub usize);
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
-pub struct RefValidSourceNodeTypeRelation(pub usize);
+pub struct ValidSourceNodeTypeRelation;
+
+impl From<usize> for ValidSourceNodeTypeRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
-pub struct RefMemberNodeTypeRelation(pub usize);
+pub struct MemberNodeTypeRelation;
+
+impl From<usize> for MemberNodeTypeRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
-pub struct RefMemberNodeTemplateRelation(pub usize);
+pub struct MemberNodeTemplateRelation;
 
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
-pub struct MemberNodeTemplateRelation(pub usize);
+impl From<usize> for MemberNodeTemplateRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
-pub struct RefValidRelationshipTypeRelation(pub usize);
+pub struct ValidRelationshipTypeRelation;
+
+impl From<usize> for ValidRelationshipTypeRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
 pub struct DirectiveRelation(pub usize);
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
-pub struct RefValidCapabilityTypeRelation(pub usize);
+pub struct ValidCapabilityTypeRelation;
+
+impl From<usize> for ValidCapabilityTypeRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
-pub struct RefValidTargetNodeTypeRelation(pub usize);
+pub struct ValidTargetNodeTypeRelation;
 
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
-pub struct RefTargetNodeRelation;
+impl From<usize> for ValidTargetNodeTypeRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct TargetNodeRelation;
 
+impl From<usize> for TargetNodeRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
+
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
-pub struct RefTargetCapabilityRelation;
+pub struct TargetCapabilityRelation;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
 pub struct WorkflowActivityRelation(pub usize);
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
-pub struct RefWorkflowRelation;
+pub struct WorkflowRelation;
+
+impl From<usize> for WorkflowRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, From)]
-pub struct RefOperationRelation;
+pub struct OperationRelation;
+
+impl From<usize> for OperationRelation {
+    fn from(_: usize) -> Self {
+        Self
+    }
+}
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct PolicyTriggerEventRelation;
@@ -381,34 +429,32 @@ pub enum Relation {
 
     MimeType(MimeTypeRelation),
     FileExt(FileExtRelation),
-    RefHasFile(RefHasFileRelation),
+    HasFile(HasFileRelation),
     Checksum(ChecksumRelation),
     ChecksumAlgorithm(ChecksumAlgorithmRelation),
 
     PrimaryArtifact(PrimaryArtifactRelation),
     DependencyArtifact(DependencyArtifactRelation),
 
-    RefValidSourceNodeType(RefValidSourceNodeTypeRelation),
-    RefValidRelationshipType(RefValidRelationshipTypeRelation),
+    ValidSourceNodeType(ValidSourceNodeTypeRelation),
+    ValidRelationshipType(ValidRelationshipTypeRelation),
 
     Directive(DirectiveRelation),
 
-    RefMemberNodeTemplate(RefMemberNodeTemplateRelation),
     MemberNodeTemplate(MemberNodeTemplateRelation),
-    RefMemberNodeType(RefMemberNodeTypeRelation),
+    MemberNodeType(MemberNodeTypeRelation),
 
-    RefValidCapabilityType(RefValidCapabilityTypeRelation),
-    RefValidTargetNodeType(RefValidTargetNodeTypeRelation),
+    ValidCapabilityType(ValidCapabilityTypeRelation),
+    ValidTargetNodeType(ValidTargetNodeTypeRelation),
 
-    RefTargetNode(RefTargetNodeRelation),
     TargetNode(TargetNodeRelation),
-    RefTargetCapability(RefTargetCapabilityRelation),
+    TargetCapability(TargetCapabilityRelation),
 
     SubstitutionMapping(SubstitutionMappingRelation),
 
     WorkflowActivity(WorkflowActivityRelation),
-    RefWorkflow(RefWorkflowRelation),
-    RefOperation(RefOperationRelation),
+    Workflow(WorkflowRelation),
+    Operation(OperationRelation),
 
     PolicyTriggerEvent(PolicyTriggerEventRelation),
 

--- a/crates/toto_tosca/src/models.rs
+++ b/crates/toto_tosca/src/models.rs
@@ -252,13 +252,10 @@ pub struct RootRelation;
 pub struct HasTypeRelation;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
-pub struct RefHasTypeRelation;
+pub struct SubstitutesTypeRelation;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct DerivedFromRelation;
-
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
-pub struct RefDerivedFromRelation;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct MimeTypeRelation;
@@ -379,10 +376,8 @@ pub enum Relation {
     Root(RootRelation),
 
     HasType(HasTypeRelation),
-    RefHasType(RefHasTypeRelation),
-
     DerivedFrom(DerivedFromRelation),
-    RefDerivedFrom(RefDerivedFromRelation),
+    SubstitutesType(SubstitutesTypeRelation),
 
     MimeType(MimeTypeRelation),
     FileExt(FileExtRelation),

--- a/crates/toto_tosca/src/semantic/hierarchy.rs
+++ b/crates/toto_tosca/src/semantic/hierarchy.rs
@@ -5,10 +5,7 @@ use crate::{ToscaCompatibleEntity, ToscaCompatibleRelation};
 pub struct Hierarchy;
 
 impl Hierarchy {
-    pub fn link<E, R>(
-        file_handle: toto_ast::GraphHandle,
-        ast: &mut toto_ast::AST<E, R>,
-    ) -> toto_ast::GraphHandle
+    pub fn link<E, R>(file_handle: toto_ast::GraphHandle, ast: &mut toto_ast::AST<E, R>)
     where
         E: ToscaCompatibleEntity,
         R: ToscaCompatibleRelation,
@@ -23,6 +20,5 @@ impl Hierarchy {
                 );
             }
         }
-        file_handle
     }
 }

--- a/crates/toto_tosca/src/semantic/hierarchy.rs
+++ b/crates/toto_tosca/src/semantic/hierarchy.rs
@@ -16,7 +16,7 @@ impl Hierarchy {
                 ast.add_edge(
                     file_handle,
                     nx,
-                    crate::Relation::from(crate::RefRootRelation).into(),
+                    crate::Relation::from(crate::RootRelation).into(),
                 );
             }
         }

--- a/crates/toto_tosca/src/semantic/import.rs
+++ b/crates/toto_tosca/src/semantic/import.rs
@@ -10,6 +10,8 @@ use toto_parser::EntityParser;
 
 use crate::{grammar::parser::ToscaGrammar, ToscaCompatibleEntity, ToscaCompatibleRelation};
 
+use super::Hierarchy;
+
 pub struct Importer {
     existing_urls: HashMap<url::Url, toto_ast::GraphHandle>,
 }
@@ -41,6 +43,7 @@ impl Importer {
         let doc_root = toto_yaml::YamlParser::parse(doc_handle, ast).unwrap();
         if let Some(file_handle) = ToscaGrammar::parse(doc_root, ast) {
             self.existing_urls.insert(uri.clone(), file_handle);
+            Hierarchy::link(file_handle, ast);
             self.import_files(uri, file_handle, ast);
             Some(file_handle)
         } else {

--- a/crates/toto_tosca/src/semantic/import.rs
+++ b/crates/toto_tosca/src/semantic/import.rs
@@ -10,8 +10,6 @@ use toto_parser::EntityParser;
 
 use crate::{grammar::parser::ToscaGrammar, ToscaCompatibleEntity, ToscaCompatibleRelation};
 
-use super::Hierarchy;
-
 pub struct Importer {
     existing_urls: HashMap<url::Url, toto_ast::GraphHandle>,
 }
@@ -43,7 +41,6 @@ impl Importer {
         let doc_root = toto_yaml::YamlParser::parse(doc_handle, ast).unwrap();
         if let Some(file_handle) = ToscaGrammar::parse(doc_root, ast) {
             self.existing_urls.insert(uri.clone(), file_handle);
-            Hierarchy::link(file_handle, ast);
             self.import_files(uri, file_handle, ast);
             Some(file_handle)
         } else {

--- a/crates/toto_tosca/src/semantic/lookup.rs
+++ b/crates/toto_tosca/src/semantic/lookup.rs
@@ -22,6 +22,7 @@ impl SimpleLookuper {
         let target_str = toto_yaml::as_string(target, ast).expect("expected string");
         let target_rel = (self.what_rel)(target_str.0.clone());
 
+        let mut path = vec![source];
         let mut curr_node = source;
         let root = loop {
             let root = ast
@@ -34,14 +35,15 @@ impl SimpleLookuper {
                     }
                 })
                 .expect(&format!(
-                    "expected {:?} to have incoming {:?} relation",
-                    curr_node, self.root.0
+                    "expected {:?} to have {:?} entity",
+                    path, self.root.1
                 ));
 
             if ast.node_weight(root).unwrap().as_tosca() == Some(&self.root.1) {
                 break root;
             }
             curr_node = root;
+            path.push(curr_node);
         };
 
         let lookuped = ast

--- a/crates/toto_tosca/src/semantic/mod.rs
+++ b/crates/toto_tosca/src/semantic/mod.rs
@@ -1,5 +1,7 @@
+pub mod hierarchy;
 pub mod import;
 pub mod lookup;
 
+pub use hierarchy::*;
 pub use import::*;
 pub use lookup::*;

--- a/crates/toto_yaml/src/lib.rs
+++ b/crates/toto_yaml/src/lib.rs
@@ -320,7 +320,5 @@ mod tests {
 
         dbg!(size_of::<Entity>() * ast.node_count() + size_of::<Relation>() * ast.edge_count());
         dbg!(Dot::new(&ast));
-
-        assert!(false);
     }
 }


### PR DESCRIPTION
- **chore: move hierarchy to semantic**
- **chore: generalize entity lookup**
- **chore: support iterative lookup**
- **fix: bring goto for import back**
- **chore: remove reftype relations**
- **chore(clippy-warning): remove assert(false)**
- **chore: remove unused imports**
- **chore: remove all ref relations**
- **feat: add goto-definition for node references**

This PR adds more flexible reference resolvers, allowing referencing
entities other than types

This feature is still WIP, some goto's may not work
